### PR TITLE
[WIP]日本語で設定の説明をいれて、自動フォーマットを効かせた

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,54 +8,61 @@
 		// Path is relataive to the devcontainer.json file.
 		"dockerfile": "Dockerfile"
 	},
-
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "pip3 install --user -r requirements.txt",
-
 	// Configure tool-specific properties.
 	"customizations": {
-		// Configure properties specific to VS Code.
+		// VS Code特有のプロパティを設定する。
 		"vscode": {
-			// Set *default* container specific settings.json values on container create.
+			// コンテナ作成時に、*default*コンテナ固有のsettings.json値を設定する。
 			"settings": {
-				// "python.linting.enabled": true,
-				// "python.linting.lintOnSave": true,
+				// Lint機能を有効にするかどうか
+				"python.linting.enabled": true,
+				// ファイル保存時にLintを実行するか
+				"python.linting.lintOnSave": true,
 				// Pylance
 				// "python.languageServer": "Pylance",
 				// "python.analysis.completeFunctionParens": true,
-
-				// Linter(flake8)
+				// Linter(flake8): コードがPEP8に準拠しているかをチェックする
 				"python.linting.flake8Path": "/usr/local/bin/flake8",
+				// pyLintをOFF
 				"python.linting.pylintEnabled": false,
+				// flake8をON
 				"python.linting.flake8Enabled": true,
-
-				// Formatter(black)
+				"python.linting.flake8Args": [
+					// black の最大文字列数(default= 88) と flake8 の最大文字列数(default= 79)と異なるため調整　(ref: https://dk521123.hatenablog.com/entry/2021/11/10/095258)
+					"--max-line-length=210",
+					// E203 :コロンの前に空白が入っている
+					// W503: 演算子の前に改行
+					// W504: 演算子の後に改行
+					"--ignore=E203,W503,W504"
+				],
+				"python.formatting.blackArgs": [
+					// black の最大文字列数(default= 88) と flake8 の最大文字列数(default= 79)と異なるため調整
+					"--line-length=210"
+				],
+				// Formatter(black): 自動的にコードを整形する
 				"python.formatting.blackPath": "/usr/local/bin/black",
+				// Pythonコードの整形に何を使用するか
 				"python.formatting.provider": "black",
-				// "python.formatting.blackArgs": [
-				// 	"--line-length=79"
-				// ],
+				// 保存時にフォーマットをON
+				"editor.formatOnSave": true,
 				"[python]": {
-					"editor.formatOnSave": true
+					"editor.defaultFormatter": null
 				}
 			},
-
 			// Add the IDs of extensions you want installed when the container is created.
 			"extensions": [
 				"ms-python.python",
 				"ms-vsliveshare.vsliveshare"
-			],
-
+			]
 			// "shutdownAction": "stopCompose"
 		}
 	}
-
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }

--- a/first-bolt-app/src/app.py
+++ b/first-bolt-app/src/app.py
@@ -4,6 +4,7 @@ import os
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 from dotenv import load_dotenv
+
 # GPT-3.5-turbo
 from langchain.chat_models import ChatOpenAI
 from langchain import LLMChain
@@ -16,6 +17,8 @@ from langchain.prompts.chat import (
     # user メッセージテンプレート
     HumanMessagePromptTemplate,
 )
+
+
 # from langchain.schema import (
 #     # それぞれ GPT-3.5-turbo API の assistant, user, system role に対応
 #     # AIMessage,
@@ -33,18 +36,15 @@ app = App(token=os.environ.get("SLACK_BOT_TOKEN"))
 llm = ChatOpenAI(temperature=0, openai_api_key=os.environ.get("OPEN_API_KEY"))
 
 # 日本語で ChatGPT っぽく丁寧に説明させる
-system_message_prompt = SystemMessagePromptTemplate.from_template(
-    "You are an assistant who thinks step by step and includes a thought path in your response. Your answers are in Japanese."
-    )
+system_message_prompt = SystemMessagePromptTemplate.from_template("You are an assistant who thinks step by step and includes a thought path in your response. Your answers are in Japanese.")
 # ユーザーからの入力
 human_template = "{text}"
 # User role のテンプレートに
 message_prompt = HumanMessagePromptTemplate.from_template(human_template)
 
 # ひとつのChatTemplateに
-chat_prompt = ChatPromptTemplate.from_messages(
-    [system_message_prompt, message_prompt])
-chat_prompt.input_variables = ['text']
+chat_prompt = ChatPromptTemplate.from_messages([system_message_prompt, message_prompt])
+chat_prompt.input_variables = ["text"]
 
 # カスタムプロンプトを入れてchain 化
 chain = LLMChain(llm=llm, prompt=chat_prompt)
@@ -75,10 +75,11 @@ chain = LLMChain(llm=llm, prompt=chat_prompt)
 @app.event("message")
 def handle_message_events(body, say):
     # メンションの内容を取得
-    text = body['event']['text']
-    say(text='回答を生成しています。しばらくお待ちください。')
+    text = body["event"]["text"]
+    say(text="回答を生成しています。しばらくお待ちください。")
     # LLMを動作させてチャンネルで発言
     say(chain.run(text=text))
+
 
 # @app.action("button_click")
 # def action_button_click(body, ack, say):


### PR DESCRIPTION
# 変更点
- 学習のため日本語で設定の説明を入れてみました
- Blackの整形されたpython codeをそのままコミットしました
- blackとflake8 と共存させる場合black の最大文字列数(default= 88) と flake8 の最大文字列数(default= 79)と
　異なるので、最大文字列数が 79< line < 88 だとエラーになってしまうということだったので一旦210でおいておいた。後ほどどのくらいの文字数がいいのかを検討したい
  - ref https://dk521123.hatenablog.com/entry/2021/11/10/095258

# わかったこと
- そもそもlinterのデバック方法がわかっていなかったのだが、試行錯誤の結果 開発コンテナー上で確認→設定変更→開発コンテナーを再ビルドで確認できることがわかった