### PR TITLE
GitHub Actionsサンプルマージの結果container環境がひらけなくなった不具合を解消

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,0 @@
-FROM mcr.microsoft.com/devcontainers/python:0-3.11
-COPY ../requirements.txt .
-RUN pip install -r ../requirements.txt

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 	"name": "bolt_sample",
 	"build": {
 		// Dockerfileを使用する場合に必要です。コンテナの中身を定義するDockerfileの場所です。パスはdevcontainer.jsonファイルからの相対パスです。
-		"dockerfile": "Dockerfile"
+		"dockerfile": "../Dockerfile"
 	},
 	// コンテナ内で参照される環境変数.
 	"containerEnv": {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/devcontainers/python:0-3.11
+COPY ./requirements.txt .
+RUN pip install -r ./requirements.txt


### PR DESCRIPTION
GitHub Actionサンプルのブランチをマージ時にcontainer環境が起動できなくなってしまった不具合を見落としてしまっていたのでその修正になります。