### PR TITLE
Dockerファイルでの requirements.txt のパスの修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM mcr.microsoft.com/devcontainers/python:0-3.11
-COPY ./requirements.txt .
-RUN pip install -r ./requirements.txt
+COPY requirements.txt .
+RUN pip install -r requirements.txt


### PR DESCRIPTION
# 現象
mainブランチで
`python app.py`を実行すると下記エラーが出る。

```
vscode ➜ /workspaces/slack_bolt_sample/first-bolt-app/src (feat/WeeklyReportFetch) $ python copybot.py 
Traceback (most recent call last):
  File "/workspaces/slack_bolt_sample/first-bolt-app/src/copybot.py", line 5, in <module>
    from langchain import LLMChain
  File "/usr/local/lib/python3.11/site-packages/langchain/__init__.py", line 6, in <module>
    from langchain.agents import MRKLChain, ReActChain, SelfAskWithSearchChain
  File "/usr/local/lib/python3.11/site-packages/langchain/agents/__init__.py", line 2, in <module>
    from langchain.agents.agent import (
  File "/usr/local/lib/python3.11/site-packages/langchain/agents/agent.py", line 16, in <module>
    from langchain.agents.tools import InvalidTool
  File "/usr/local/lib/python3.11/site-packages/langchain/agents/tools.py", line 8, in <module>
    from langchain.tools.base import BaseTool, Tool, tool
  File "/usr/local/lib/python3.11/site-packages/langchain/tools/__init__.py", line 10, in <module>
    from langchain.tools.bing_search.tool import BingSearchResults, BingSearchRun
  File "/usr/local/lib/python3.11/site-packages/langchain/tools/bing_search/__init__.py", line 3, in <module>
    from langchain.tools.bing_search.tool import BingSearchResults, BingSearchRun
  File "/usr/local/lib/python3.11/site-packages/langchain/tools/bing_search/tool.py", line 10, in <module>
    from langchain.utilities.bing_search import BingSearchAPIWrapper
  File "/usr/local/lib/python3.11/site-packages/langchain/utilities/__init__.py", line 3, in <module>
    from langchain.utilities.apify import ApifyWrapper
  File "/usr/local/lib/python3.11/site-packages/langchain/utilities/apify.py", line 5, in <module>
    from langchain.document_loaders import ApifyDatasetLoader
  File "/usr/local/lib/python3.11/site-packages/langchain/document_loaders/__init__.py", line 77, in <module>
    from langchain.document_loaders.pyspark_dataframe import PySparkDataFrameLoader
  File "/usr/local/lib/python3.11/site-packages/langchain/document_loaders/pyspark_dataframe.py", line 7, in <module>
    import psutil
ModuleNotFoundError: No module named 'psutil'
```

# 原因？
よくわからないが、LangChainまわりのモジュールを読み込むときにLangChainをうまく読み込めてなさそうな雰囲気がしたので、Dockerファイルのrequirements.txtのファイルのパスが妙なのかなと思い修正した
(なんで動かないのか、これで何故動くのかはよくわからない・・・・)

# 参照
https://pbl2023.slack.com/archives/C053JSQ4QH1/p1685626866132379