### PR TITLE
Markdown出力したNotionドキュメントを要約してくれる機能

### DIFF
--- a/first-bolt-app/src/copybot_md.py
+++ b/first-bolt-app/src/copybot_md.py
@@ -1,0 +1,127 @@
+import os
+import re
+
+import requests
+from dotenv import load_dotenv
+from langchain import LLMChain
+from langchain.callbacks.manager import CallbackManager
+from langchain.chat_models import ChatOpenAI
+from langchain.prompts.chat import (ChatPromptTemplate,
+                                    HumanMessagePromptTemplate,
+                                    SystemMessagePromptTemplate)
+from slack_bolt import App
+from slack_bolt.adapter.socket_mode import SocketModeHandler
+from slack_sdk.errors import SlackApiError
+from utility import SlackCallbackHandler
+
+load_dotenv()
+
+
+class CoPyBotMd:
+    def __init__(self):
+        self.slack_app = App(token=os.environ.get("SLACK_BOT_TOKEN"))
+        self.register_listeners()
+
+    def create_chain(self, llm):
+        system_template = """
+        You are an assistant who thinks step by step and includes a thought path in your response.
+        Your answers are in Japanese.
+        """
+        system_message_prompt = SystemMessagePromptTemplate.from_template(system_template)
+
+        human_template = """
+        以下の文章を要約してね。
+        なお、要約は箇条書きでお願い。
+        また、項目立てをして作成してね。
+            {md_content}
+        """
+        human_message_prompt = HumanMessagePromptTemplate.from_template(human_template)
+
+        chat_prompt = ChatPromptTemplate.from_messages([system_message_prompt, human_message_prompt])
+        chat_prompt.input_variables = ["md_content"]
+
+        chain = LLMChain(llm=llm, prompt=chat_prompt)
+
+        return chain
+
+    def get_llm(self, say):
+        def say_function(message):
+            say(message)
+
+        callback_manager = CallbackManager([SlackCallbackHandler(say_function)]) if self.is_streaming else None
+
+        return ChatOpenAI(temperature=0,
+                          openai_api_key=os.environ.get("OPENAI_API_KEY"),
+                          model_name="gpt-3.5-turbo",
+                          streaming=self.is_streaming,
+                          callback_manager=callback_manager)
+
+    def register_listeners(self):
+        @self.slack_app.message(re.compile("(マークダウン要約|よろしく)"))
+        def message_streamling_mode_selection(say):
+            text = "こんにちは。co-py-bot だよ。\nストリーミングモードで実行する？"
+            say(
+                blocks=[
+                    {
+                        "type": "section",
+                        "block_id": "section677",
+                        "text": {"type": "mrkdwn", "text": text},
+                        "accessory": {
+                            "action_id": "mode_selection",
+                            "type": "static_select",
+                            "placeholder": {"type": "plain_text", "text": "選択してください"},
+                            "options": [{"text": {"type": "plain_text", "text": "はい"}, "value": "1"}, {"text": {"type": "plain_text", "text": "いいえ"}, "value": "0"}],
+                        },
+                    }
+                ],
+                text=text,
+            )
+
+        @self.slack_app.action("mode_selection")
+        def message_ryokai(body, ack, say):
+            ack()
+            self.is_streaming = int(body["actions"][0]["selected_option"]["value"])
+            if self.is_streaming:
+                say("了解。ストリーミングモードで実行するね。\n準備はできたよ。要約して欲しいマークダウンファイル(.md)を投稿してね。")
+            else:
+                say("了解。ストリーミングモードはオフで実行するね。\n準備はできたよ。要約して欲しいマークダウンファイル(.md)を投稿してね。")
+
+        @self.slack_app.event('message')
+        def handle_file_share_events(body, say, client):
+            try:
+                self.is_streaming
+            except AttributeError:
+                self.is_streaming = 0
+            say("ファイルを受け取ったよ。なかなか良い文章だね。要約しているからちょっと待ってね。")
+            event = body['event']
+            self.process_file_share(event, say, client)
+
+    def process_file_share(self, event, say, client):
+        try:
+            file_info = client.files_info(file=event['files'][0]['id']).data['file']
+            if file_info['name'][-3:] == '.md':
+                file_url = file_info['url_private_download']
+                header = {'Authorization': f"Bearer {os.environ.get('SLACK_BOT_TOKEN')}"}
+                file_res = requests.get(file_url, headers=header)
+                if file_res.status_code != 200:
+                    print(f"Failed to download file: status code {file_res.status_code}")
+                    print(f"Response body: {file_res.text}")
+                    return
+                md_content = file_res.text
+
+                self.chain = self.create_chain(self.get_llm(say))
+                summary = self.chain.run(md_content=md_content[:3950])
+                say(summary)
+            else:
+                say("指定されたファイルが .md 形式ではありません。.md ファイルをアップロードしてください。")
+
+        except SlackApiError as e:
+            print(f"Error getting file info: {e}")
+
+    def start(self):
+        SocketModeHandler(self.slack_app, os.environ["SLACK_APP_TOKEN"]).start()
+
+
+if __name__ == "__main__":
+    bot = CoPyBotMd()
+    bot.start()

--- a/first-bolt-app/src/utility.py
+++ b/first-bolt-app/src/utility.py
@@ -1,0 +1,65 @@
+
+from typing import Any, Dict, List, Union
+
+from langchain.callbacks.base import BaseCallbackHandler
+from langchain.schema import AgentAction
+
+
+class AcademicPeriod:
+    def __init__(self, quarter: str, start_week: int, end_week: int):
+        self.quarter = quarter
+        self.weeks = [f"{i:02d}" for i in range(start_week, end_week + 1)]
+
+
+ACADEMIC_PERIODS = {
+    "4": AcademicPeriod("1Q", 1, 4),
+    "5": AcademicPeriod("1Q", 5, 9),
+    "6": AcademicPeriod("2Q", 1, 4),
+    "7": AcademicPeriod("2Q", 5, 9),
+    "8": AcademicPeriod("2Q", 9, 10),
+    "9": AcademicPeriod("3Q", 1, 4),
+    "10": AcademicPeriod("3Q", 5, 9),
+    "11": AcademicPeriod("4Q", 1, 4),
+    "12": AcademicPeriod("4Q", 5, 9),
+    "1": AcademicPeriod("4Q", 9, 10),
+}
+
+
+class SlackCallbackHandler(BaseCallbackHandler):
+    def __init__(self, say_function):
+        self.say = say_function
+        self.token_count = 0
+        self.content = []
+
+    def on_llm_start(
+        self, serialized: Dict[str, Any], prompts: List[str], **kwargs: Any
+    ) -> Any:
+        pass
+
+    def on_llm_new_token(self, token: str, **kwargs: Any) -> Any:
+        if self.token_count < 100:
+            self.token_count += 1
+            self.content.append(token)
+        else:
+            self.token_count = 0
+            print(''.join(self.content))
+            self.say(''.join(self.content))
+            self.content = []
+
+    def on_llm_error(
+        self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
+    ) -> Any:
+        """Run when LLM errors."""
+
+    def on_chain_start(
+        self, serialized: Dict[str, Any], inputs: Dict[str, Any], **kwargs: Any
+    ) -> Any:
+        print(f"on_chain_start {serialized['name']}")
+
+    def on_tool_start(
+        self, serialized: Dict[str, Any], input_str: str, **kwargs: Any
+    ) -> Any:
+        print(f"on_tool_start {serialized['name']}")
+
+    def on_agent_action(self, action: AgentAction, **kwargs: Any) -> Any:
+        print(f"on_agent_action {action}")


### PR DESCRIPTION
後々のバックログで取り組む、週報データベース以外の幅広いドキュメントを読み込ませてその内容を要約・抽出するための機能として、Notionドキュメント（議事録など）をMarkdown出力したファイルを読み込ませてタスク実行させる機能について、モブプロでの参照用に実装サンプルを作成しました。

# 動作確認手順
  (1) スプリント１のモブプロでインストールしたSlack botの`SLACK_APP_TOKEN`と`SLACK_BOT_TOKEN`を`.env`で設定する
  (2) `OPENAI_API_KEY`を`.env`で設定する
  (3) [Slack APIページ](https://api.slack.com/apps/)でSlackアプリの`ソケットモード`をオンに設定する
  (4) 同じく上記ページでサイドメニューの`OAuth & Permissions`を選択して遷移するページで`Bot Token Scopes`に`files:read`を追加
  (5) dev_contenaierを開く
  (6) コンテナ内でカレントディレクトリを`/workspaces/slack_bolt_sample`にする
  (7) コンテナ内で`python3 first-bolt-app/src/copybot_md.py`を実行
  (8) SlackボットをインストールしたSlackチャンネルで「マークダウン要約してね」と投稿する。
  (9) Slackボットが反応するので、ストリーミングモードで実行するか否かを選択し、ボットが「準備ができたよ」と返してきたら、[動作確認用_Monthly_Review_05.md](https://github.com/yellow-seed/slack_bolt_sample/files/11642221/Monthly_Review_05.md)を投稿する。
  (10) 投稿したマークダウンファイルに関する要約文が返ってきたら動作確認完了

内部の処理は次のようになっています。
(1) 投稿されたマークダウンファイルからテキスト情報を抽出
(2) 抽出したテキスト情報をChatGPTのプロンプトに入力
(3) 要約文出力


# その他
今回の実装もストリーミングモードで実行すると100tokensごとに回答を行います。

マークダウンファイルを利用する形式を実装したのは、PDFファイルと比べて抽出後のテキストデータがh1やh2などで構造化されているほか、余計な情報を含まないため、チャンキング（文章を一定の法則で区切る処理）を行わずに、ドキュメント作成時の構造に従って連想配列型などに変換して利用できるというメリットがあるためです。
これは例えば、「４月の議論を要約して」という風に、正確に特定の箇所を指定したい場合に大きなメリットになるかなと思います。前処理次第ではコサイン類似度のような曖昧さの残るものではなくkeyで正確に指定できるため（keyで該当箇所を指定する機能はこのプルリクには含めていませんが、以前中内が実装した[こちらのNotebook](https://colab.research.google.com/drive/1aI7xsFKAe8K59dETqc19nIftcuAFkuYq?usp=drive_link)でそうした実装例を作成しています。）
ただ、Notionにはマークダウン形式でのエクスポート機能があるから良いですが、一般的に会社ドキュメントがマークダウン形式で蓄積されているケースは少ないことが想定され、汎用性には劣るので、より広範な利用場面が想定されるPDF形式も別のブランチで実装しました。

【動作確認用マークダウンファイル】
動作確認はこちらのマークダウンファイルを使いました。よろしければご利用ください。
[動作確認用_Monthly_Review_05.md](https://github.com/yellow-seed/slack_bolt_sample/files/11642221/Monthly_Review_05.md)
Notionの５月のマンスリーレビュー資料をエクスポートしたものです。



![image](https://github.com/yellow-seed/slack_bolt_sample/assets/82159549/aed3c88c-bd96-4df9-b3df-a8e295486c54)