### PR TITLE
GitLensなど拡張機能を追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -75,7 +75,15 @@
 				// liveshareの拡張
 				"ms-vsliveshare.vsliveshare",
 				// pythonのインデントを自動で生成する拡張 ref:https://marketplace.visualstudio.com/items?itemName=KevinRose.vsc-python-indent
-				"KevinRose.vsc-python-indent"
+				"KevinRose.vsc-python-indent",
+				// GitHub Copilot
+				"GitHub.copilot",
+				// GitLens gitを視覚的に表現する拡張
+				"eamodio.gitlens",
+				// Flake8 Lint
+				"ms-python.flake8",
+				// Black Formatter
+				"ms-python.black-formatter"
 			]
 			// devcontainer.jsonをサポートするツールが、関連するツールウィンドウを閉じる/シャットダウンする際に、コンテナを停止させるかどうかを示します。
 			// 値は、none、stopContainer（イメージまたはDockerfileのデフォルト）、stopCompose（Docker Composeのデフォルト）です。

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 ./first-bolt-app/src/__pycache__/*
 *.env
 *.pyc
+__pycache__/
+.pytest_cache/


### PR DESCRIPTION
## チケット

* SB番号などを記入してください
https://www.notion.so/Git-Lens-devcontainer-499ec3fecaaa40ec9df8c8e1817dcdca?pvs=4


## やったこと

* このプルリクで何をしたのか？
VSCodeの拡張機能を追加しました
* GitHub Copilot
* GitLens
* flake8
* Black
いずれも使うことになっていたものに関しての拡張機能になります。

.gitignoreを変更して__pycache__をpushしないようにしました。特に必要ないフォルダなので。

## できるようになること（ユーザ目線）

* 何ができるようになるのか？（あれば。無いなら「無し」でOK）
拡張機能インストールの手間が省けます。

## 動作させるために必要な作業

* どのような動作確認するためにどのような前準備をすればいいか
コンテナには入らない状態のほうがいいです。
ブランチをローカルに持ってきたら、右下にRebuildに関するサジェストみたいなものがでていると思うので、それを選択します。

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
