### PR TITLE
cloudrun_sampleに対するdocker-composeをまずは導入した

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,10 +3,20 @@
 {
 	// UIに表示されるdevコンテナの名前
 	"name": "bolt_sample",
+
 	"build": {
 		// Dockerfileを使用する場合に必要です。コンテナの中身を定義するDockerfileの場所です。パスはdevcontainer.jsonファイルからの相対パスです。
 		"dockerfile": "../Dockerfile"
 	},
+
+	// "dockerComposeFile": [
+	// 	// Docker Composeを使用する場合に必要です。コンテナの中身を定義するDocker Composeファイルの場所です。パスはdevcontainer.jsonファイルからの相対パスです。
+	// 	"../docker-compose.yml"
+	// ],
+	// // devcontainerでshellなど？で使用するdocker composeのservice名
+  // "service": "app",
+  // // 指定したserviceコンテナのworkspaceフォルダ
+  // "workspaceFolder": "/app",
 	// コンテナ内で参照される環境変数.
 	"containerEnv": {
 		// タイムゾーンが Asia/Tokyoになるよう設定。時刻に起因する問題の調査は難しいので、ここで明示的に設定
@@ -86,10 +96,10 @@
 				"ms-python.black-formatter",
 				// Annotationコメントを簡単に検索できる拡張
 				"Gruntfuggly.todo-tree"
-			]
+			],
 			// devcontainer.jsonをサポートするツールが、関連するツールウィンドウを閉じる/シャットダウンする際に、コンテナを停止させるかどうかを示します。
 			// 値は、none、stopContainer（イメージまたはDockerfileのデフォルト）、stopCompose（Docker Composeのデフォルト）です。
-			// "shutdownAction": "stopCompose"
+			"shutdownAction": "stopCompose"
 		}
 	}
 	// 代わりにrootとして接続する場合は、コメントを解除してください。詳しくは、 https://aka.ms/dev-containers-non-root.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -99,7 +99,7 @@
 			],
 			// devcontainer.jsonをサポートするツールが、関連するツールウィンドウを閉じる/シャットダウンする際に、コンテナを停止させるかどうかを示します。
 			// 値は、none、stopContainer（イメージまたはDockerfileのデフォルト）、stopCompose（Docker Composeのデフォルト）です。
-			"shutdownAction": "stopCompose"
+			// "shutdownAction": "stopCompose"
 		}
 	}
 	// 代わりにrootとして接続する場合は、コメントを解除してください。詳しくは、 https://aka.ms/dev-containers-non-root.

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.pyc
 __pycache__/
 .pytest_cache/
+*ngrok.yml

--- a/cloudrun-sample/README.md
+++ b/cloudrun-sample/README.md
@@ -2,10 +2,10 @@
 ## 前準備
 
 ### ngrok
-ngrokでサーバーを立ち上げて `https://xxxx-xxxx-xxx-xxx-xxx.ngrok-free.app -> http://localhost:3000` となるようにする
+ngrokでサーバーを立ち上げて `https://xxxx-xxxx-xxx-xxx-xxx.ngrok-free.app -> http://localhost:11111` となるようにする
 
 ```
-ngrok http 3000
+ngrok http 11111
 ```
 
 ↓ngrokで生成されたURLをSlackアプリのevent-subscriptionsに登録する必要がある
@@ -28,6 +28,21 @@ python main.py
 ## dockerで立ち上げる場合
 docker build -t my_app -f Dockerfile_dev .
 docker run -p 11111:11111 --env-file .env  my_app
+
+## docker-composeで立ち上げる場合
+
+### 事前準備
+
+1. ngrok.yml.sampleをもとにngrok.ymlを作成する
+1. ngrok(https://dashboard.ngrok.com/get-started/your-authtoken)にログインしてYour Authtokenをコピーしてngrok.ymlのauthtokenに設定する
+
+### 起動方法
+
+1. カレントディレクトリがcloudrun-sampleなことを確認して `docker compose up` で起動する
+1. slackのevent-subscriptionsにngrokで生成されたURLを登録する必要があるので、ngrokが発行したURLが確認できるページ(http://localhost:4040/)をブラウザで開く
+1. SlackのEvent Subscriptionに{表示されているURL}/slack/eventsを登録する
+1. 以降の流れは通常のngrok使用時と変わらない
+1. 起動したサービスを終了する際はcontrol + cで終了できる
 
 
 ## CloudRun

--- a/cloudrun-sample/docker-compose.yml
+++ b/cloudrun-sample/docker-compose.yml
@@ -38,10 +38,3 @@ services:
 networks:
     ngrok-net:
       name: ngrok
-        
-    # ngrok:
-    #     image: wernight/ngrok
-    #     depends_on:
-    #       - my_app
-    #     environment:
-    #       - NGROK_PORT=my_app:11111

--- a/cloudrun-sample/docker-compose.yml
+++ b/cloudrun-sample/docker-compose.yml
@@ -1,0 +1,47 @@
+version: '3'
+services:
+    my_app:
+        build: 
+            context: .
+            dockerfile: Dockerfile_dev
+        volumes:
+            - .:/my_app
+        environment:
+            # - PORT=11111
+            - PYTHONUNBUFFERED=True
+        ports:
+            - 11111:11111
+        env_file:
+            - .env
+        networks:
+            - ngrok-net
+
+    ngrok:
+        image: ngrok/ngrok:latest
+        depends_on:
+          - my_app
+        restart: unless-stopped
+        command:
+          - "start"
+          - "--all"
+          - "--config"
+          - "/etc/ngrok.yml"
+          # - "http"
+          # - "my_app:11111"
+        volumes:
+          - ./ngrok.yml:/etc/ngrok.yml
+        ports:
+          - 4040:4040
+        networks:
+          - ngrok-net
+
+networks:
+    ngrok-net:
+      name: ngrok
+        
+    # ngrok:
+    #     image: wernight/ngrok
+    #     depends_on:
+    #       - my_app
+    #     environment:
+    #       - NGROK_PORT=my_app:11111

--- a/cloudrun-sample/ngrok.yml.sample
+++ b/cloudrun-sample/ngrok.yml.sample
@@ -1,0 +1,9 @@
+version: "2"
+authtoken: YOUR_AUTH_TOKEN # ngrokにログインすると確認できる認証情報トークン
+console_ui: true   # コンソールUIを有効にするかどうか
+web_addr: localhost:4040
+
+tunnels:
+  my_app:
+    addr: my_app:11111   # 公開したいローカルのポート番号
+    proto: http   # 使用するプロトコル (http, https, tcp, tls のいずれか)


### PR DESCRIPTION
## チケット
> スプリントバックログのURLなどを記入してください
> バックログページのURL(https://www.notion.so/d42c086417984526b2b1e1c7f3de8416)

チケット番号はありません

## やったこと
> このプルリクで何をしたのか？

cloudrun_sampleディレクトリに対する変更。
ngrokを自分のPCにインストールしなくてもコマンド一つでslackのアプリとngrokがセットアップが完了した状態で起動する仕組みを確立した。


## できるようになること（ユーザ目線）
> 何ができるようになるのか？（あれば。無いなら「無し」でOK）

ngrokを今後インストールする必要がなくなる(現在はcloudrun_sampleの動作確認のみが対象範囲)

## 動作させるために必要な前準備
> どのような動作確認するためにどのような前準備をすればいいか

READMEの「docker-composeで立ち上げる場合」 に記載した内容をここにも添付する

```
### 事前準備

1. ngrok.yml.sampleをもとにngrok.ymlを作成する
1. ngrok(https://dashboard.ngrok.com/get-started/your-authtoken)にログインしてYour Authtokenをコピーしてngrok.ymlのauthtokenに設定する

### 起動方法

1. カレントディレクトリがcloudrun-sampleなことを確認して `docker compose up` で起動する
1. slackのevent-subscriptionsにngrokで生成されたURLを登録する必要があるので、ngrokが発行したURLが確認できるページ(http://localhost:4040/)をブラウザで開く
1. SlackのEvent Subscriptionに{表示されているURL}/slack/eventsを登録する
1. 以降の流れは通常のngrok使用時と変わらない
1. 起動したサービスを終了する際はcontrol + cで終了できる
```

### Slack関連
> ソケットモードは「ON・OFF」どちらですか？　関係がない場合はこちらの項目を削除してください

ngrokを使った動作確認なのでOFF

## 実行手順
> 変更があったり記載したほうがいいと思った場合に記入


## その他
> レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

今後devcontainerの方もdocker-compose化を進めて、ngrokを簡単に使えるようにする予定です。
今回はその一段回目。
