### PR TITLE
faissを使ったベクトルデータベースの高速化

### DIFF
--- a/first-bolt-app/src/copybot_pdf.py
+++ b/first-bolt-app/src/copybot_pdf.py
@@ -16,7 +16,7 @@ from langchain.chat_models import ChatOpenAI
 from langchain.prompts.chat import (ChatPromptTemplate,
                                     HumanMessagePromptTemplate,
                                     SystemMessagePromptTemplate)
-from openai.embeddings_utils import cosine_similarity, get_embedding
+from openai.embeddings_utils import get_embedding
 from pdfminer.high_level import extract_pages, extract_text
 from pdfminer.layout import LTTextContainer
 from pdfminer.pdfparser import PDFSyntaxError

--- a/first-bolt-app/src/faiss_sample.py
+++ b/first-bolt-app/src/faiss_sample.py
@@ -1,0 +1,153 @@
+import faiss
+import numpy as np
+from openai import Embedding
+from openai.embeddings_utils import get_embedding
+from utility import num_tokens
+
+
+class Test:
+    def __init__(self):
+        self.target_texts = [
+            "今日は雨森雅司に賽振られたねえ",
+            "小泉今日子は雨後の筍喰えるかな",
+            "マンゴー食べれてよかったねえ",
+            "良い天気だね～～",
+            "キウイはビタミンCが豊富だね",
+            "カナダは北米に位置しているよ",
+            "アイスランドは温泉が有名だね",
+            "サッカーは楽しいスポーツだ",
+            "日本は四季がはっきりしているね",
+            "バナナは栄養価が高いよ",
+            "オーストラリアはコアラがいるよ",
+            "バスケットボールは高身長が有利だ",
+            "インドはカレーがおいしいね",
+            "フランスはワインが有名だよ",
+            "ブラジルはサンバの国だね",
+            "夏は海水浴が楽しいね",
+            "ブルーベリーは目にいいよ",
+            "エジプトはピラミッドがあるよ",
+            "冬はスキーが楽しいね",
+            "パリは芸術の盛んだった都市だよ",
+            "春は桜がきれいだね",
+            "中国は人口が多い国だよ",
+            "フィジーはビーチが素晴らしいね",
+            "イタリアはピザが有名だよ",
+            "オレンジは甘酸っぱいね",
+            "アフリカはサバンナが広がっているよ",
+            "夏はバーベキューが楽しいね",
+            "アイルランドはビールがおいしいよ",
+            "ドイツはビールが有名だね",
+            "秋は紅葉がきれいだよ",
+            "ロンドンは雨が多いね",
+            "日本は寿司が有名だよ",
+            "春は新しい出会いがあるね",
+            "ブドウはワインの原料だよ",
+            "スペインは闘牛が有名だね",
+            "冬は雪だるま作りが楽しいよ",
+            "トマトは野菜の一種だよ",
+            "ハワイはサーフィンが楽しいね",
+            "ロシアは広大な国土を持っているよ",
+            "森林浴は心地よいね",
+            "デンマークは自転車が多いよ",
+            "カボチャはハロウィンの象徴だね",
+            "ベネズエラは美しいビーチがあるよ",
+            "冬は雪合戦が楽しいね",
+            "スイスはチーズが美味しいよ",
+            "メキシコはタコスが有名だね",
+            "南アフリカはサファリが人気だよ",
+            "バドミントンは速いラリーがあるね",
+            "ポーランドは美しい城があるよ",
+            "ソウルはショッピングが楽しいね",
+            "ペットは癒しをくれるよ",
+            "スウェーデンはIKEAの本国だね",
+            "プールは夏に涼しいね",
+            "ジャガイモは料理の基本だよ",
+            "オランダはチューリップが有名だね",
+            "ベルギーはワッフルが美味しいよ",
+            "釣りは静かな趣味だね",
+            "マラソンは耐久力が試されるよ",
+            "シンガポールは夜景がきれいだね",
+            "アボカドは健康に良いよ",
+            "ノルウェーはフィヨルドが有名だね",
+            "チェスは頭の体操だよ",
+            "イスラエルは歴史が深いね",
+            "スペインはフラメンコが魅力的だよ",
+            "ヨガはリラックスに良いね",
+            "アメリカはバーガーが人気だよ",
+            "イタリアはジェラートが美味しいね",
+            "バレエは優雅なダンスだよ",
+            "サッカーは国際的なスポーツだね",
+            "ドバイは超高層ビルが立つよ",
+            "カプサイシンは辛さの元だよ",
+            "ニュージーランドは羊が多いね",
+            "オリーブオイルは料理に欠かせないよ",
+            "オーストラリアはコアラがいるよ",
+            "バスケットは高速なゲームだね",
+            "エクアドルは赤道が通るよ"] * 3
+
+        response = Embedding.create(input=self.target_texts,
+                                    model="text-embedding-ada-002")
+        # 色んなプロパティを含んでいるresponseの中から、ベクトル表現のみを取り出したリストを作る
+        self.embedding = [record["embedding"] for record in response["data"]]
+        self.embedding_array = np.array(self.embedding).astype("float32")
+
+
+    def init_voronoi_indexer(self):
+        """
+        クラスタリングによってデータ空間をボロノイ領域に分割することにより
+        高速な近傍探索を可能にするためのindexerを初期化するメソッド
+        ボロノイ領域の紹介はこちら --> https://ja.wikipedia.org/?curid=91418
+        このアルゴリズムでは質問クエリに対して、その周辺領域のみで探索できるので
+        総当たりせずに済むので探索にかかる時間を大幅に短縮できる
+        """
+
+        # 30ページを超える分量の多いPDFファイルに適用
+        n_pages = len(self.embedding_array)
+        if n_pages > 30:
+            # ボロノイ領域の数
+            # クラスタリング空間を定義する量子化器（Quantizer）つくる（L2ノルム）
+            self.quantizer = faiss.IndexFlatL2(1536)
+            # 下記引数の1536はembeddingの次元数、20はボロノイ領域の数（ボロノイの数は増やすと精度上がって処理時間増えるトレードオフ）
+            # embeddingの次元数は`text-embedding-ada-002`以外を使う場合には変更が必要。BERT-baseなら768次元など。
+            self.indexer = faiss.IndexIVFFlat(self.quantizer, 1536, 5)
+            # ベクトルデータベースからボロノイ領域を生成
+            self.indexer.train(self.embedding_array)
+            # ボロノイ領域にデータを追加
+            self.indexer.add(self.embedding_array)
+        else:
+            # 分量の少ないテキストデータに対しては総当たり探索でも問題ないので
+            # 単体のL2ノルムアルゴリズムを使う。
+            self.indexer = faiss.IndexFlatL2(1536)
+            # データを追加
+            self.indexer.add(self.embedding_array)
+
+    def voronoi_diagram_search(self, query_embedding):
+        """
+        ボロノイ領域による近傍探索を実行するメソッド
+
+        Args:
+            query_embedding (np.ndarray): 質問クエリをembeddingしたやつ
+
+        Returns:
+            top_n_pages (pandas.DataFrame): 上位n件のテキスト情報を格納したデータフレーム
+        """
+        # 近傍探索の実行。
+        query_embedding = np.array([query_embedding]).astype("float32")
+        _, idx = self.indexer.search(query_embedding, 3)
+        return self.target_texts[idx[0][0]]
+
+    def answer_about_pdf(self, query):
+        # query文字列とそのembedding
+        query_embedding = get_embedding(query, engine="text-embedding-ada-002")
+
+        # ボロノイ探索を実行。上位3件のテキストを取得
+        self.init_voronoi_indexer()
+        result = self.voronoi_diagram_search(query_embedding)
+        return result
+
+
+if __name__ == "__main__":
+    query = "今日は雨振らんくてよかったねえ"
+    test = Test()
+    result = test.answer_about_pdf(query)
+    print(result)

--- a/first-bolt-app/src/faiss_sample.py
+++ b/first-bolt-app/src/faiss_sample.py
@@ -1,9 +1,14 @@
+import os
+
 import faiss
 import numpy as np
+import openai
+from dotenv import load_dotenv
 from openai import Embedding
 from openai.embeddings_utils import get_embedding
-from utility import num_tokens
 
+load_dotenv()
+openai.api_key = os.environ.get("OPENAI_API_KEY")
 
 class Test:
     def __init__(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ rich
 flask
 notion_client
 PyGithub
+faiss-cpu
+tiktoken


### PR DESCRIPTION
## チケット
> スプリントバックログのURLなどを記入してください

https://www.notion.so/DB-9679232affc14150ae1dfdc8ba1d8e9d?pvs=4


## やったこと
> このプルリクで何をしたのか？

より本格的なベクトルデータベースで用いられる[faiss](https://github.com/facebookresearch/faiss)を使えるようにしました。
ドキュメント群からユーザー質問文に関連する個所を抽出する際により高性能なアルゴリズムで近傍探索を実行できるようになり、応答速度が改善します。

※ チャンキングされた複数のテキストデータを変換したベクトルからなるデータ空間を[ボロノイ領域](https://ja.wikipedia.org/?curid=91418)を使ったクラスタリングとL2ノルムを併用して近傍探索することで、総当たり法によらずに発見的に解をみつけだします。

## できるようになること（ユーザ目線）
> 何ができるようになるのか？（あれば。無いなら「無し」でOK）

応答速度が速くなる

## 動作させるために必要な前準備と実行手順
> どのような動作確認するためにどのような前準備をすればいいか

1. Dockerコンテナ内の`/workspaces/slack_bolt_sample`をカレントディレクトリにする。
```
cd /workspaces/slack_bolt_sample
```

2. 必要なライブラリをインストールする（リビルドでも可）
```
pip install -r requirements.txt
```
3. 動作確認用スクリプトを実行する
```
python first-bolt-app/src/test_faiss.py
```
4. 上記を実行すると、`今日は雨振らんくてよかったねえ`という文章に関連する文章をドキュメント群から探索します。`良い天気だね～～`など、関連する文章が抽出されてきたらOK

## 補足
この実装は以前のプルリク#15 をアップデートする形で実装しています。全体の動作確認をしなおす必要がある場合には#15 と同じく[こちらの手順](https://github.com/AIIT-OikawaPBL-2023/slack_bolt_sample/pull/15#issue-1739317790)に沿うことで実行できます。
ただ、今回更新した箇所はSlackAPIなどは無関係の箇所のため、無用に煩雑な確認作業になるのを避ける目的で上記動作確認用スクリプトを用意した次第です。
動作確認用スクリプトは今回アップデートした`copybot_pdf.py`の`CoPyBotPDF`クラスを継承した`Test`クラスを使い、新たに実装したメソッドのみを動かす内容となっています。

### Slack関連
> ソケットモードは「ON・OFF」どちらですか？　関係がない場合はこちらの項目を削除してください

動作確認用スクリプトのみの動作の場合は設定不要
