### PR TITLE
Slack APIのEventとBlockを構造化した

### DIFF
--- a/api-data-struct/sl_main.py
+++ b/api-data-struct/sl_main.py
@@ -24,7 +24,7 @@ class SlackAppController(object):
             body_st = slack_event_st.purseEventMessageCB(body)
             print(body_st.event)
 
-            builder = slack_block_st.HelloBuilder(say_text="元気にしてましたか?")
+            builder = slack_block_st.HelloBuilder(say_text="元気にしてましたか? >")
             blocks_dict = builder.hello_build
             say(**blocks_dict)
 
@@ -61,7 +61,7 @@ class SlackAppController(object):
         def dataPicker01Handler(ack, body, logger):
             print("data picker 01 handler")
             ack()
-            print(body["type"], body["actions"][0]["selected_date"])
+            print(body["type"], body["actions"][0]["selected_date"])  # ここは力尽きたので、パースしていない
 
     def startSocketMode(self):
         self.handler.start()

--- a/api-data-struct/sl_main.py
+++ b/api-data-struct/sl_main.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+from rich import print
+from dotenv import load_dotenv
+from slack_bolt import App
+from slack_bolt.adapter.socket_mode import SocketModeHandler
+
+import slack_event_st
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/../api-data-struct")
+
+
+class SlackAppController(object):
+    def __init__(self, slack_app, handler) -> None:
+        self.handler = handler
+
+        @slack_app.event(slack_event_st.EventType_Const.message)
+        def messageHandler(body, say):
+            print("message handler")
+            body_st = slack_event_st.purseEventMessageCB(body)
+            print(body_st.event)
+
+        @slack_app.event(slack_event_st.EventType_Const.reaction_added)
+        def reactionAddedHandler(body, say):
+            print("reaction added handler")
+            body_st = slack_event_st.purseEventReactionAddedCB(body)
+            print(body_st.event)
+
+        @slack_app.event(slack_event_st.EventType_Const.reaction_removed)
+        def reactionRemovedHandler(body, say):
+            print("reaction removed handler")
+            body_st = slack_event_st.purseEventReactionRemovedCB(body)
+            print(body_st.event)
+
+        @slack_app.event(slack_event_st.EventType_Const.app_mention)
+        def AppMentionHandler(body, say):
+            print("app mention handler")
+            body_st = slack_event_st.purseEventAppMentionCB(body)
+            print(body_st.event)
+
+    def startSocketMode(self):
+        self.handler.start()
+
+
+if __name__ == "__main__":
+    # 秘密情報をロード
+    load_dotenv()
+
+    # ロードした情報を格納
+    access_token = os.environ.get("SLACK_BOT_TOKEN")
+    app_token = os.environ.get("SLACK_APP_TOKEN")
+
+    slack_app = App(token=access_token)
+    handler = SocketModeHandler(slack_app, app_token)
+    slack_controller = SlackAppController(slack_app, handler)
+
+    slack_controller.startSocketMode()

--- a/api-data-struct/sl_main.py
+++ b/api-data-struct/sl_main.py
@@ -24,14 +24,20 @@ class SlackAppController(object):
             body_st = slack_event_st.purseEventMessageCB(body)
             print(body_st.event)
 
-            blocks_dict = slack_block_st.bulidBlocks()
+            builder = slack_block_st.HelloBuilder(say_text="元気にしてましたか?")
+            blocks_dict = builder.hello_build
             say(**blocks_dict)
 
+        # Reactionすると日付選択が出てくる
         @slack_app.event(slack_event_st.EventType_Const.reaction_added)
         def reactionAddedHandler(body, say):
             print("reaction added handler")
             body_st = slack_event_st.purseEventReactionAddedCB(body)
             print(body_st.event)
+
+            builder = slack_block_st.DatePickerBuilder()
+            blocks_dict = builder.input_block_build
+            say(**blocks_dict)
 
         @slack_app.event(slack_event_st.EventType_Const.reaction_removed)
         def reactionRemovedHandler(body, say):
@@ -39,11 +45,23 @@ class SlackAppController(object):
             body_st = slack_event_st.purseEventReactionRemovedCB(body)
             print(body_st.event)
 
+            builder = slack_block_st.DatePickerBuilder()
+            blocks_dict = builder.section_block_build
+            say(**blocks_dict)
+
         @slack_app.event(slack_event_st.EventType_Const.app_mention)
         def AppMentionHandler(body, say):
             print("app mention handler")
+            print(body)
             body_st = slack_event_st.purseEventAppMentionCB(body)
             print(body_st.event)
+
+        # 日付選択すると下記が呼ばれる
+        @slack_app.action("datepicker_01")
+        def dataPicker01Handler(ack, body, logger):
+            print("data picker 01 handler")
+            ack()
+            print(body["type"], body["actions"][0]["selected_date"])
 
     def startSocketMode(self):
         self.handler.start()

--- a/api-data-struct/sl_main.py
+++ b/api-data-struct/sl_main.py
@@ -9,6 +9,7 @@ from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 
 import slack_event_st
+import slack_block_st
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/../api-data-struct")
 
@@ -22,6 +23,9 @@ class SlackAppController(object):
             print("message handler")
             body_st = slack_event_st.purseEventMessageCB(body)
             print(body_st.event)
+
+            blocks_dict = slack_block_st.bulidBlocks()
+            say(**blocks_dict)
 
         @slack_app.event(slack_event_st.EventType_Const.reaction_added)
         def reactionAddedHandler(body, say):

--- a/api-data-struct/slack_block_st.py
+++ b/api-data-struct/slack_block_st.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+from rich import print
+import dataclasses
+
+# Composition objects
+# https://api.slack.com/reference/block-kit/composition-objects
+
+
+# Text Object
+# https://api.slack.com/reference/block-kit/composition-objects#text
+@dataclasses.dataclass(frozen=True)
+class Block_TextType_Const:
+    plain_text: str = "plain_text"
+    mrkdwn: str = "mrkdwn"
+
+
+# Text Object
+# https://api.slack.com/reference/block-kit/composition-objects#text
+@dataclasses.dataclass(frozen=True)
+class Block_Text_ST:
+    type: Block_TextType_Const
+    text: str
+
+
+#    emoji: bool = False
+#    verbatim: bool = False
+
+
+# Block要素
+# https://api.slack.com/reference/block-kit/block-elements
+
+
+# Section Block
+# https://api.slack.com/reference/block-kit/blocks#section
+@dataclasses.dataclass(frozen=True)
+class SectionBlock_ST:
+    text: Block_Text_ST
+    type: str = "section"
+
+
+#    block_id: str = "undefined"
+#    fields: list[Block_Text_ST] = None
+#    accessory: dict = dataclasses.field(default_factory=dict)
+
+
+# https://api.slack.com/messaging/composing/layouts#stack_of_blocks
+# Top-levelの要約テキストを提供する必要がある。これは通知などに使われている。
+# https://github.com/slackapi/python-slack-sdk/issues/965#issuecomment-906383420
+@dataclasses.dataclass(frozen=True)
+class Blocks_ST:
+    blocks: list[SectionBlock_ST]
+    text: str = "New message"
+
+
+def bulidBlocks(summery_text="first saying", text="Hello, world!") -> list[dict]:
+    blocks = Blocks_ST(
+        [
+            SectionBlock_ST(
+                text=Block_Text_ST(
+                    type=Block_TextType_Const.plain_text,
+                    text=text,
+                )
+            )
+        ],
+        text=summery_text,
+    )
+    blocks_dict = dataclasses.asdict(blocks)
+    print(blocks_dict)
+
+    return blocks_dict

--- a/api-data-struct/slack_block_st.py
+++ b/api-data-struct/slack_block_st.py
@@ -271,7 +271,7 @@ class HelloBuilder(object):
         """
         # Block要素でBlockを定義
         hello_in_section_block = SectionBlock_ST(text=Compo_Text_ST(type=Compo_TextType_Const.plain_text, text="Hello!!!"))
-        text_in_section_block = SectionBlock_ST(text=Compo_Text_ST(type=Compo_TextType_Const.plain_text, text=say_text))
+        text_in_section_block = SectionBlock_ST(text=Compo_Text_ST(type=Compo_TextType_Const.plain_text, text=say_text), accessory=Elem_Image_ST())
 
         # Blockリストを定義
         self._hello_build = Blocks_ST([hello_in_section_block, text_in_section_block], text=notify_text)

--- a/api-data-struct/slack_block_st.py
+++ b/api-data-struct/slack_block_st.py
@@ -330,3 +330,13 @@ class DatePickerBuilder(object):
     @property
     def section_block_build(self) -> dict:
         return slackStructAsDict(self._section_block_build)
+
+
+if __name__ == "__main__":
+    builder = DatePickerBuilder()
+    input_blocks_dict = builder.input_block_build
+    section_block_dict = builder.section_block_build
+
+    # 出力結果を https://app.slack.com/block-kit-builder/ に貼り付ける
+    # print('{ "blocks": ', input_blocks_dict["blocks"], "}")
+    print('{ "blocks": ', section_block_dict["blocks"], "}")

--- a/api-data-struct/slack_block_st.py
+++ b/api-data-struct/slack_block_st.py
@@ -243,6 +243,8 @@ def __deleteNoneKey(slack_dict: dict) -> dict:
 def slackStructAsDict(blocks: Blocks_ST) -> dict:
     """
     slack blockの構造体をdictに変換する
+    Noneの要素をSlack APIに投げるとErrorになってしまうので、削除する
+    そのために__deleteNoneKey()を再帰的に呼び出している。
 
     Args:
         blocks (Blocks_ST): slack blockの構造体
@@ -252,24 +254,6 @@ def slackStructAsDict(blocks: Blocks_ST) -> dict:
     """
     blocks_dict = dataclasses.asdict(blocks)
     blocks_dict = __deleteNoneKey(blocks_dict)
-
-    return blocks_dict
-
-
-def bulidBlocks(summery_text="first saying", text="Hello, world!") -> dict:
-    blocks = Blocks_ST(
-        [
-            SectionBlock_ST(
-                text=Compo_Text_ST(
-                    type=Compo_TextType_Const.plain_text,
-                    text=text,
-                )
-            )
-        ],
-        text=summery_text,
-    )
-    blocks_dict = slackStructAsDict(blocks)
-    print(blocks_dict)
 
     return blocks_dict
 
@@ -299,8 +283,11 @@ class HelloBuilder(object):
 
 class DatePickerBuilder(object):
     def __init__(self) -> None:
+        """
+        Dateを選択するブロックを作成する。
+        """
         # Elementを定義
-        data_picker_elem = Elem_DatePicker_ST(
+        date_picker_elem = Elem_DatePicker_ST(
             action_id="datepicker_01",  # action_idの値でHandlingしている。このIDの場合、@slack_app.action("datepicker_01")で捕まえられる。
             placeholder=Compo_Text_ST(type=Compo_TextType_Const.plain_text, text="日付選択"),
         )
@@ -310,13 +297,13 @@ class DatePickerBuilder(object):
 
         data_in_input_block = InputBlock_ST(
             label=Compo_Text_ST(type=Compo_TextType_Const.plain_text, text="日付"),
-            element=data_picker_elem,
+            element=date_picker_elem,
             hint=Compo_Text_ST(type=Compo_TextType_Const.plain_text, text="ヒントは出せない"),
         )
 
         data_in_section_block = SectionBlock_ST(
             text=Compo_Text_ST(type=Compo_TextType_Const.plain_text, text="日付選択Section"),
-            accessory=data_picker_elem,
+            accessory=date_picker_elem,
         )
 
         # Blockリストを定義

--- a/api-data-struct/slack_block_st.py
+++ b/api-data-struct/slack_block_st.py
@@ -3,14 +3,15 @@
 from rich import print
 import dataclasses
 
+# Blockの一番細かい要素
 # Composition objects
 # https://api.slack.com/reference/block-kit/composition-objects
 
 
-# Text Object
+# Text Type Field
 # https://api.slack.com/reference/block-kit/composition-objects#text
 @dataclasses.dataclass(frozen=True)
-class Block_TextType_Const:
+class Compo_TextType_Const:
     plain_text: str = "plain_text"
     mrkdwn: str = "mrkdwn"
 
@@ -18,30 +19,192 @@ class Block_TextType_Const:
 # Text Object
 # https://api.slack.com/reference/block-kit/composition-objects#text
 @dataclasses.dataclass(frozen=True)
-class Block_Text_ST:
-    type: Block_TextType_Const
+class Compo_Text_ST:
+    type: Compo_TextType_Const
     text: str
+    emoji: bool = None
+    verbatim: bool = None
 
 
-#    emoji: bool = False
-#    verbatim: bool = False
+# Dialog Style Field
+# https://api.slack.com/reference/block-kit/block-elements#button__fields (style)
+class Compo_DialogStyle_Const:
+    default: str = "default"
+    primary: str = "primary"
+    danger: str = "danger"
 
 
-# Block要素
+# Confirmation Dialog Object
+# https://api.slack.com/reference/block-kit/composition-objects
+@dataclasses.dataclass(frozen=True)
+class Compo_Dialog_ST:
+    title: Compo_Text_ST
+    text: Compo_Text_ST
+    confirm: Compo_Text_ST
+    deny: Compo_Text_ST
+    style: Compo_DialogStyle_Const = Compo_DialogStyle_Const.primary
+
+
+# Option Object
+# https://api.slack.com/reference/block-kit/composition-objects#option
+# The url attribute is only available in overflow menus.
+# https://api.slack.com/reference/block-kit/block-elements#overflow
+@dataclasses.dataclass(frozen=True)
+class Compo_Option_ST:
+    text: Compo_Text_ST
+    value: str
+    description: Compo_Text_ST = None
+    url: str = None
+
+
+# Option Group Object
+# Provides a way to group options in a select menu or multi-select menu.
+# https://api.slack.com/reference/block-kit/composition-objects#option_group
+@dataclasses.dataclass(frozen=True)
+class Compo_OptionGroup_ST:
+    label: Compo_Text_ST
+    options: list[Compo_Option_ST]
+
+
+# Dispatch Action Configuration Trigger field
+# https://api.slack.com/reference/block-kit/composition-objects#dispatch_action_config (trigger_actions_on)
+class Compo_DispatchTrigger_Const:
+    on_enter_pressed: str = "on_enter_pressed"
+    on_character_entered: str = "on_character_entered"
+
+
+# Dispatch Action Configuration Object
+# https://api.slack.com/reference/block-kit/composition-objects#dispatch_action_config
+@dataclasses.dataclass(frozen=True)
+class Compo_DispatchActionConfig_ST:
+    trigger_actions_on: list[Compo_DispatchTrigger_Const]
+
+
+# Input Parameter Object
+# https://api.slack.com/reference/block-kit/composition-objects#input_parameter
+@dataclasses.dataclass(frozen=True)
+class Compo_InputParameter_ST:
+    name: str
+    value: str
+
+
+# Trigger Object
+# https://api.slack.com/reference/block-kit/composition-objects#trigger
+@dataclasses.dataclass(frozen=True)
+class Compo_Trigger_ST:
+    url: str
+    customizable_input_parameters: list[Compo_InputParameter_ST] = None
+
+
+# Workflow Object
+# https://api.slack.com/reference/block-kit/composition-objects#workflow
+@dataclasses.dataclass(frozen=True)
+class Compo_Workflow_ST:
+    trigger: Compo_Trigger_ST
+
+
+# Blockの一番細かい要素はここまで
+# ここからはBlock要素 Object
 # https://api.slack.com/reference/block-kit/block-elements
 
 
-# Section Block
+# Button Element Object
+# https://api.slack.com/reference/block-kit/block-elements#button
+@dataclasses.dataclass(frozen=True)
+class Elem_Button_ST:
+    text: Compo_Text_ST  # type: plain_textのみ可能
+    action_id: str
+    type: str = "button"
+    url: str = None
+    value: str = None
+    style: Compo_DialogStyle_Const = Compo_DialogStyle_Const.primary
+    confirm: Compo_Dialog_ST = None
+    accessibility_label: str = None
+
+
+# Checkbox Element Object
+# https://api.slack.com/reference/block-kit/block-elements#checkboxes
+@dataclasses.dataclass(frozen=True)
+class Elem_Checkbox_ST:
+    action_id: str
+    options: list[Compo_Option_ST]
+    type: str = "checkboxes"
+    initial_options: list[Compo_Option_ST] = None
+    confirm: Compo_Dialog_ST = None
+    focus_on_load: bool = None
+
+
+# Date picker element object
+# https://api.slack.com/reference/block-kit/block-elements#datepicker
+@dataclasses.dataclass(frozen=True)
+class Elem_DatePicker_ST:
+    action_id: str
+    type: str = "datepicker"
+    placeholder: Compo_Text_ST = None
+    initial_date: str = None
+    confirm: Compo_Dialog_ST = None
+    focus_on_load: bool = None
+    placeholder: Compo_Text_ST = None
+
+
+# Image Element Object
+# https://api.slack.com/reference/block-kit/block-elements#image
+@dataclasses.dataclass(frozen=True)
+class Elem_Image_ST:
+    type: str = "image"
+    image_url: str = "http://placekitten.com/700/500"
+    alt_text: str = "Multiple cute kittens"
+
+
+# Select menu of static option element object
+# https://api.slack.com/reference/block-kit/block-elements#static_select
+@dataclasses.dataclass(frozen=True)
+class Elem_SelectStatic_ST:
+    action_id: str
+    type: str = "static_select"
+    options: list[Compo_Option_ST] = None
+    option_groups: list[Compo_OptionGroup_ST] = None
+    initial_option: Compo_Option_ST = None
+    confirm: Compo_Dialog_ST = None
+    focus_on_load: bool = None
+    placeholder: Compo_Text_ST = None
+
+
+# ここからは Block Object
+# https://api.slack.com/reference/block-kit/blocks
+
+
+# Actions Block Object
+# https://api.slack.com/reference/block-kit/blocks#actions
+@dataclasses.dataclass(frozen=True)
+class ActionsBlock_ST:
+    elements: list[Elem_Button_ST | Elem_DatePicker_ST | Elem_SelectStatic_ST]
+    type: str = "actions"
+    block_id: str = None
+
+
+# Section Block Object
 # https://api.slack.com/reference/block-kit/blocks#section
 @dataclasses.dataclass(frozen=True)
 class SectionBlock_ST:
-    text: Block_Text_ST
     type: str = "section"
+    text: Compo_Text_ST = None
+    block_id: str = None
+    fields: list[Compo_Text_ST] = None
+    accessory: Elem_Button_ST | Elem_Checkbox_ST | Elem_DatePicker_ST | Elem_Image_ST | Elem_SelectStatic_ST = None
 
 
-#    block_id: str = "undefined"
-#    fields: list[Block_Text_ST] = None
-#    accessory: dict = dataclasses.field(default_factory=dict)
+# Input Block Object
+# https://api.slack.com/reference/block-kit/blocks#input
+@dataclasses.dataclass(frozen=True)
+class InputBlock_ST:
+    label: Compo_Text_ST
+    type: str = "input"
+    element: Elem_Checkbox_ST | Elem_DatePicker_ST | Elem_SelectStatic_ST = None
+    dispatch_action: bool = None
+    block_id: str = None
+    hint: Compo_Text_ST = None
+    optional: bool = None
 
 
 # https://api.slack.com/messaging/composing/layouts#stack_of_blocks
@@ -49,23 +212,121 @@ class SectionBlock_ST:
 # https://github.com/slackapi/python-slack-sdk/issues/965#issuecomment-906383420
 @dataclasses.dataclass(frozen=True)
 class Blocks_ST:
-    blocks: list[SectionBlock_ST]
-    text: str = "New message"
+    blocks: list[ActionsBlock_ST | SectionBlock_ST | InputBlock_ST]
+    text: str = "Notification!"
 
 
-def bulidBlocks(summery_text="first saying", text="Hello, world!") -> list[dict]:
+def __deleteNoneKey(slack_dict: dict) -> dict:
+    """
+    slack_dictの中にNoneのkeyがあれば削除する
+
+    Args:
+        slack_dict (dict): 削除対象のdict
+
+    Returns:
+        dict: 処理結果
+    """
+    for key, dict_value in list(slack_dict.items()):
+        if dict_value is None:
+            del slack_dict[key]
+        else:
+            if isinstance(dict_value, dict):
+                __deleteNoneKey(dict_value)
+            elif isinstance(dict_value, list):
+                for list_elem in dict_value:
+                    if isinstance(list_elem, dict):
+                        __deleteNoneKey(list_elem)
+
+    return slack_dict
+
+
+def slackStructAsDict(blocks: Blocks_ST) -> dict:
+    """
+    slack blockの構造体をdictに変換する
+
+    Args:
+        blocks (Blocks_ST): slack blockの構造体
+
+    Returns:
+        dict: slack blockの構造体をdictに変換したもの
+    """
+    blocks_dict = dataclasses.asdict(blocks)
+    blocks_dict = __deleteNoneKey(blocks_dict)
+
+    return blocks_dict
+
+
+def bulidBlocks(summery_text="first saying", text="Hello, world!") -> dict:
     blocks = Blocks_ST(
         [
             SectionBlock_ST(
-                text=Block_Text_ST(
-                    type=Block_TextType_Const.plain_text,
+                text=Compo_Text_ST(
+                    type=Compo_TextType_Const.plain_text,
                     text=text,
                 )
             )
         ],
         text=summery_text,
     )
-    blocks_dict = dataclasses.asdict(blocks)
+    blocks_dict = slackStructAsDict(blocks)
     print(blocks_dict)
 
     return blocks_dict
+
+
+# 以下builderのサンプル実装
+# SectionBlock_ST | ActionsBlock_ST | InputBlock_STのBlockを組み合わせて作る。
+class HelloBuilder(object):
+    def __init__(self, say_text="Hello!!!", notify_text="Hello Notification!!!") -> None:
+        """
+        Botに喋らせるためのBlockを作成する。
+
+        Args:
+            say_text (str, optional): 喋らせることを記す. Defaults to "Hello!!!".
+            notify_text (str, optional): Slack通知のテキストを記す. Defaults to "Hello Notification!!!".
+        """
+        # Block要素でBlockを定義
+        hello_in_section_block = SectionBlock_ST(text=Compo_Text_ST(type=Compo_TextType_Const.plain_text, text="Hello!!!"))
+        text_in_section_block = SectionBlock_ST(text=Compo_Text_ST(type=Compo_TextType_Const.plain_text, text=say_text))
+
+        # Blockリストを定義
+        self._hello_build = Blocks_ST([hello_in_section_block, text_in_section_block], text=notify_text)
+
+    @property
+    def hello_build(self) -> dict:
+        return slackStructAsDict(self._hello_build)
+
+
+class DatePickerBuilder(object):
+    def __init__(self) -> None:
+        # Elementを定義
+        data_picker_elem = Elem_DatePicker_ST(
+            action_id="datepicker_01",  # action_idの値でHandlingしている。このIDの場合、@slack_app.action("datepicker_01")で捕まえられる。
+            placeholder=Compo_Text_ST(type=Compo_TextType_Const.plain_text, text="日付選択"),
+        )
+
+        # Block要素でBlockを定義
+        text_in_section_block = SectionBlock_ST(text=Compo_Text_ST(type=Compo_TextType_Const.plain_text, text="日付を選択してください"))
+
+        data_in_input_block = InputBlock_ST(
+            label=Compo_Text_ST(type=Compo_TextType_Const.plain_text, text="日付"),
+            element=data_picker_elem,
+            hint=Compo_Text_ST(type=Compo_TextType_Const.plain_text, text="ヒントは出せない"),
+        )
+
+        data_in_section_block = SectionBlock_ST(
+            text=Compo_Text_ST(type=Compo_TextType_Const.plain_text, text="日付選択Section"),
+            accessory=data_picker_elem,
+        )
+
+        # Blockリストを定義
+        self._input_block_build = Blocks_ST([text_in_section_block, data_in_input_block])
+        self._section_block_build = Blocks_ST([text_in_section_block, data_in_section_block])
+
+    @property
+    def input_block_build(self) -> dict:
+        return slackStructAsDict(self._input_block_build)
+
+    @property
+    def section_block_build(self) -> dict:
+        return slackStructAsDict(self._section_block_build)

--- a/api-data-struct/slack_event_st.py
+++ b/api-data-struct/slack_event_st.py
@@ -147,10 +147,13 @@ class EventReactionRemoved_ST:
 class EventAppMention_ST:
     user: str
     text: str
+    team: str
     channel: str
     ts: str
     event_ts: str
     type: str = EventType_Const.app_mention
+    client_msg_id: str = None
+    blocks: dict = None
 
 
 # Event Callbackで得たデータ構造
@@ -176,8 +179,6 @@ class __EventCB_ST:
 class EventMessageCB_ST:
     token: str
     team_id: str
-    context_team_id: str
-    context_enterprise_id: str
     api_app_id: str
     event: EventMessage_ST | EventMsgDelete_ST
     type: str
@@ -186,6 +187,8 @@ class EventMessageCB_ST:
     authorizations: list[Authorization_ST]
     is_ext_shared_channel: bool
     event_context: str
+    context_team_id: str = None
+    context_enterprise_id: str = None
 
 
 # https://api.slack.com/apis/connections/events-api#callback-field

--- a/api-data-struct/slack_event_st.py
+++ b/api-data-struct/slack_event_st.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+
+import dataclasses
+
+
+# 要素
+# https://api.slack.com/apis/connections/events-api#event-type-structure
+@dataclasses.dataclass(frozen=True)
+class Item_ST:
+    type: str
+    channel: str
+    ts: str
+
+
+# https://api.slack.com/apis/connections/events-api#authorizations
+@dataclasses.dataclass(frozen=True)
+class Authorization_ST:
+    enterprise_id: str
+    team_id: str
+    user_id: str
+    is_bot: bool
+
+
+# Eventタイプごとのデータ構造を定義
+# https://api.slack.com/events
+# 定数であることを_Constで表現している。
+@dataclasses.dataclass(frozen=True)
+class EventType_Const:
+    message: str = "message"
+    app_mention: str = "app_mention"
+    reaction_added: str = "reaction_added"
+    reaction_removed: str = "reaction_removed"
+    user_status_changed: str = "user_status_changed"
+
+
+# https://api.slack.com/events/message#subtypes
+@dataclasses.dataclass(frozen=True)
+class EventMsgSubtypes_Const:
+    bot_message: str = "bot_message"
+    me_message: str = "me_message"
+    message_deleted: str = "message_deleted"
+    message_changed: str = "message_changed"
+    message_replied: str = "message_replied"
+
+
+# https://api.slack.com/events/message/message_changed
+# editedの中身
+@dataclasses.dataclass(frozen=True)
+class Edited_ST:
+    user: str
+    ts: str
+
+
+# ここから下がEventに関するデータ構造
+# https://api.slack.com/events/message
+@dataclasses.dataclass(frozen=True)
+class EventMessage_ST:
+    type: str = EventType_Const.message
+    subtype: str = None
+    text: str = None
+    blocks: dict = None  # TODO
+    team: str = None
+    channel: str = None
+    channel_type: str = None
+    user: str = None
+    client_msg_id: str = None
+    ts: str = None
+    event_ts: str = None
+
+    # スレッドメッセージの場合は下記に値が入っている
+    # https://api.slack.com/messaging/retrieving#finding_threads
+    thread_ts: str = None
+
+    # スレッドにぶら下がっているメッセージの場合は下記に値が入っている
+    # https://api.slack.com/messaging/retrieving#pulling_threads
+    parent_user_id: str = None
+
+    # スレッドの親メッセージの場合は下記に値が入っている
+    # https://api.slack.com/messaging/retrieving#pulling_threads
+    reply_count: int = 0
+    reply_users_count: int = 0
+    reply_users: list[str] = None  # Max 5 by slack api document
+    latest_reply: str = None
+    is_locked: bool = None
+    subscribed: bool = None
+    last_read: str = None
+
+    # メッセージを変更した場合は下記に値が入っている
+    # https://api.slack.com/events/message/message_changed
+    edited: Edited_ST = None
+    source_team: str = None
+    user_team: str = None
+
+
+# https://api.slack.com/events/message/message_changed
+@dataclasses.dataclass(frozen=True)
+class EventMsgChange_ST:
+    message: EventMessage_ST = None
+    previous_message: EventMessage_ST = None
+    type: str = EventType_Const.message
+    subtype: str = EventMsgSubtypes_Const.message_changed
+    channel: str = None
+    hidden: bool = None
+    ts: str = None
+    event_ts: str = None
+    channel_type: str = None
+
+
+# https://api.slack.com/events/message/message_deleted
+@dataclasses.dataclass(frozen=True)
+class EventMsgDelete_ST:
+    previous_message: EventMessage_ST = None
+    channel: str = None
+    hidden: bool = None
+    deleted_ts: str = None
+    event_ts: str = None
+    ts: str = None
+    channel_type: str = None
+    type: str = EventType_Const.message
+    subtype: str = EventMsgSubtypes_Const.message_deleted
+
+
+# https://api.slack.com/events/reaction_added
+@dataclasses.dataclass(frozen=True)
+class EventReactionAdded_ST:
+    user: str
+    reaction: str
+    item: Item_ST
+    item_user: str
+    event_ts: str
+    type: str = EventType_Const.reaction_added
+
+
+# https://api.slack.com/events/reaction_removed
+@dataclasses.dataclass(frozen=True)
+class EventReactionRemoved_ST:
+    user: str
+    reaction: str
+    item: Item_ST
+    item_user: str
+    event_ts: str
+    type: str = EventType_Const.reaction_removed
+
+
+# https://api.slack.com/events/app_mention
+@dataclasses.dataclass(frozen=True)
+class EventAppMention_ST:
+    user: str
+    text: str
+    channel: str
+    ts: str
+    event_ts: str
+    type: str = EventType_Const.app_mention
+
+
+# Event Callbackで得たデータ構造
+# https://api.slack.com/apis/connections/events-api#callback-field
+@dataclasses.dataclass(frozen=False)
+class __EventCB_ST:
+    token: str
+    team_id: str
+    context_team_id: str
+    context_enterprise_id: str
+    api_app_id: str
+    event: object
+    type: str
+    event_id: str
+    event_time: int
+    authorizations: list[Authorization_ST]
+    is_ext_shared_channel: bool
+    event_context: str
+
+
+# https://api.slack.com/apis/connections/events-api#callback-field
+@dataclasses.dataclass(frozen=True)
+class EventMessageCB_ST:
+    token: str
+    team_id: str
+    context_team_id: str
+    context_enterprise_id: str
+    api_app_id: str
+    event: EventMessage_ST | EventMsgDelete_ST
+    type: str
+    event_id: str
+    event_time: int
+    authorizations: list[Authorization_ST]
+    is_ext_shared_channel: bool
+    event_context: str
+
+
+# https://api.slack.com/apis/connections/events-api#callback-field
+@dataclasses.dataclass(frozen=True)
+class EventReactionAddedCB_ST:
+    token: str
+    team_id: str
+    context_team_id: str
+    context_enterprise_id: str
+    api_app_id: str
+    event: EventReactionAdded_ST
+    type: str
+    event_id: str
+    event_time: int
+    authorizations: list[Authorization_ST]
+    is_ext_shared_channel: bool
+    event_context: str
+
+
+# https://api.slack.com/apis/connections/events-api#callback-field
+@dataclasses.dataclass(frozen=True)
+class EventReactionRemovedCB_ST:
+    token: str
+    team_id: str
+    context_team_id: str
+    context_enterprise_id: str
+    api_app_id: str
+    event: EventReactionRemoved_ST
+    type: str
+    event_id: str
+    event_time: int
+    authorizations: list[Authorization_ST]
+    is_ext_shared_channel: bool
+    event_context: str
+
+
+# https://api.slack.com/apis/connections/events-api#callback-field
+@dataclasses.dataclass(frozen=True)
+class EventAppMentionCB_ST:
+    token: str
+    team_id: str
+    context_team_id: str
+    context_enterprise_id: str
+    api_app_id: str
+    event: EventAppMention_ST
+    type: str
+    event_id: str
+    event_time: int
+    authorizations: list[Authorization_ST]
+    is_ext_shared_channel: bool
+    event_context: str
+
+
+# ここからパーサーの関数を定義
+def __purseEventCB(purse_target: dict) -> __EventCB_ST:
+    """
+    EventのCallbackで得たデータのパース共通処理
+    # https://api.slack.com/apis/connections/events-api#callback-field
+
+    Args:
+        purse_target (dict): パース対象
+
+    Returns:
+        __EventCB_ST: パース結果
+    """
+    channel_msg_cb = EventMessageCB_ST(**purse_target)
+    authorizations = []
+    for authorization in authorizations:
+        authorizations.append(Authorization_ST(**authorization))
+
+    ret = __EventCB_ST(
+        token=channel_msg_cb.token,
+        team_id=channel_msg_cb.team_id,
+        context_team_id=channel_msg_cb.context_team_id,
+        context_enterprise_id=channel_msg_cb.context_enterprise_id,
+        api_app_id=channel_msg_cb.api_app_id,
+        event=None,  # event.typeによって変わる
+        event_id=channel_msg_cb.event_id,
+        event_time=channel_msg_cb.event_time,
+        authorizations=authorizations,
+        is_ext_shared_channel=channel_msg_cb.is_ext_shared_channel,
+        event_context=channel_msg_cb.event_context,
+        type=channel_msg_cb.type,
+    )
+
+    return ret
+
+
+def purseEventMessageCB(purse_target: dict) -> EventMessageCB_ST:
+    """
+    EventのCallbackで得たデータにおいて
+    event.type = "message"だった場合のパース処理
+    # https://api.slack.com/apis/connections/events-api#callback-field
+
+    Args:
+        purse_target (dict): パース対象
+
+    Returns:
+        EventMessageCB_ST: パース結果
+    """
+    # Eventをパースする
+    purse_result = __purseEventCB(purse_target)
+    purse_result.event = __purseEventMessage(purse_target["event"])
+    # 出力の型に変換する
+    purse_result_dict = dataclasses.asdict(purse_result)
+    ret = EventMessageCB_ST(**purse_result_dict)
+    return ret
+
+
+def purseEventReactionAddedCB(purse_target: dict) -> EventReactionAddedCB_ST:
+    """
+    EventのCallbackで得たデータにおいて
+    event.type = "reaction_added"だった場合のパース処理
+    # https://api.slack.com/apis/connections/events-api#callback-field
+
+    Args:
+        purse_target (dict): パース対象
+
+    Returns:
+        EventReactionAddedCB_ST: パース結果
+    """
+    purse_result = __purseEventCB(purse_target)
+    purse_result.event = EventReactionAdded_ST(**purse_target["event"])
+    # 出力の型に変換する
+    purse_result_dict = dataclasses.asdict(purse_result)
+    ret = EventReactionAddedCB_ST(**purse_result_dict)
+    return ret
+
+
+def purseEventReactionRemovedCB(purse_target: dict) -> EventReactionRemovedCB_ST:
+    """
+    EventのCallbackで得たデータにおいて
+    event.type = "reaction_removed"だった場合のパース処理
+    # https://api.slack.com/apis/connections/events-api#callback-field
+
+    Args:
+        purse_target (dict): パース対象
+
+    Returns:
+        EventReactionRemovedCB_ST: パース結果
+    """
+    purse_result = __purseEventCB(purse_target)
+    purse_result.event = EventReactionRemoved_ST(**purse_target["event"])
+    # 出力の型に変換する
+    purse_result_dict = dataclasses.asdict(purse_result)
+    ret = EventReactionRemovedCB_ST(**purse_result_dict)
+    return ret
+
+
+def purseEventAppMentionCB(purse_target: dict) -> EventAppMentionCB_ST:
+    """
+    EventのCallbackで得たデータにおいて
+    event.type = "app_mention"だった場合のパース処理
+    # https://api.slack.com/apis/connections/events-api#callback-field
+
+    Args:
+        purse_target (dict): パース対象
+
+    Returns:
+        EventAppMentionCB_ST: パース結果
+    """
+    purse_result = __purseEventCB(purse_target)
+    purse_result.event = EventAppMention_ST(**purse_target["event"])
+    # 出力の型に変換する
+    purse_result_dict = dataclasses.asdict(purse_result)
+    ret = EventAppMentionCB_ST(**purse_result_dict)
+    return ret
+
+
+def __purseEventMessage(purse_target: dict) -> EventMessage_ST | EventMsgChange_ST | EventMsgDelete_ST:
+    """
+    event.type = "message"のパース処理
+    # https://api.slack.com/events/message
+    # https://api.slack.com/events/message/message_changed
+    # https://api.slack.com/events/message/message_deleted
+
+    Args:
+        purse_target (dict): パース対象
+
+    Returns:
+        EventMessage_ST | EventMsgChange_ST | EventMsgDelete_ST: パース結果
+    """
+    # MessageのSubtypeによってパースするクラスを変える
+    if "subtype" not in purse_target.keys():
+        ret = EventMessage_ST(**purse_target)
+        return ret
+
+    # Messageが削除されたとき
+    if purse_target["subtype"] == EventMsgSubtypes_Const.message_deleted:
+        channel_msg_delete = EventMsgDelete_ST(**purse_target)
+        ret = EventMsgDelete_ST(
+            previous_message=EventMessage_ST(**channel_msg_delete.previous_message),
+            channel=channel_msg_delete.channel,
+            hidden=channel_msg_delete.hidden,
+            deleted_ts=channel_msg_delete.deleted_ts,
+            event_ts=channel_msg_delete.event_ts,
+            ts=channel_msg_delete.ts,
+            channel_type=channel_msg_delete.channel_type,
+            subtype=channel_msg_delete.subtype,
+            type=channel_msg_delete.type,
+        )
+    # Messageが編集されたとき
+    elif purse_target["subtype"] == EventMsgSubtypes_Const.message_changed:
+        channel_msg_change = EventMsgChange_ST(**purse_target)
+        ret = EventMsgChange_ST(
+            message=EventMessage_ST(**channel_msg_change.message),
+            previous_message=EventMessage_ST(**channel_msg_change.previous_message),
+            type=channel_msg_change.type,
+            subtype=channel_msg_change.subtype,
+            channel=channel_msg_change.channel,
+            hidden=channel_msg_change.hidden,
+            ts=channel_msg_change.ts,
+            event_ts=channel_msg_change.event_ts,
+            channel_type=channel_msg_change.channel_type,
+        )
+    # その他Messageに関するアクションがあったとき
+    else:
+        ret = EventMessage_ST(**purse_target)
+
+    return ret
+
+
+if __name__ == "__main__":
+    pass

--- a/api-data-struct/slack_event_st.py
+++ b/api-data-struct/slack_event_st.py
@@ -58,7 +58,7 @@ class EventMessage_ST:
     type: str = EventType_Const.message
     subtype: str = None
     text: str = None
-    blocks: dict = None  # TODO
+    blocks: list[dict] = None
     team: str = None
     channel: str = None
     channel_type: str = None


### PR DESCRIPTION
## チケット
https://www.notion.so/Slack-API-89b9c7e7c1b74c30b4daff2add2fcae5?pvs=4

## やったこと
- dataclassesを用いてSlack APIのEventとBlockを構造化した
- SlackのEventのデータをパースした
- 日付選択ができるようになった


## できるようになること（ユーザ目線）
- Slack APIのEventとBlockに関して、VS CODEで型ヒントが利くようになる。データへのアクセスが辞書型の時より迷わないでできる。

## 動作させるために必要な前準備
- .envにSLACK_APP_TOKEN/SLACK_BOT_TOKEN/SLACK_SIGNING_SECRETを定義していること。
- botを任意のチャンネルに参加させる
  - botを作成していない場合は、https://github.com/AIIT-OikawaPBL-2023/slack_bolt_sample/pull/32 の実行手順を全て実行してbotを作成する。
  - その時、sample_manifest.jsonは本投稿のマニュフェストファイルに示したデータに書き換えること。

## Slack関連
ソケットモードは「ON」

## 実行手順1
1. sl_main.pyを実行する
2. botが参加しているチャンネルでリアクションを追加する。
3. botが日付選択を提案する。
4. 日付を選択すると、コンソール上にその日付が出力される。
![image](https://github.com/AIIT-OikawaPBL-2023/slack_bolt_sample/assets/128585616/5342fc2a-39ce-4362-9b63-cc416f53a6b9)

## 実行手順2
1. slack_block_st.pyを実行する。
2. 出力結果を https://app.slack.com/block-kit-builder/ に貼り付ける。
3. 結果が生成される。

## 実行手順3 (興味がある人向け：Builderの型ヒントを確認する)
1. slack_block_stのL.300 DatePickerBuilderが日付選択を生成するビルダークラスである。
2. __init__(self)の中身を写経してみると、型ヒントが効いていることが分かる。
3. 実装を任意に変更してみて、出力結果を https://app.slack.com/block-kit-builder/ に貼り付ける。
4. 結果が生成される。

## マニュフェストファイル
```
{
    "display_information": {
        "name": "Reaction App",
        "description": "Slack APIのお試し",
        "background_color": "#2f7782"
    },
    "features": {
        "bot_user": {
            "display_name": "I'm Bot",
            "always_online": false
        }
    },
    "oauth_config": {
        "scopes": {
            "bot": [
                "app_mentions:read",
                "calls:read",
                "calls:write",
                "channels:history",
                "channels:read",
                "chat:write",
                "groups:history",
                "im:history",
                "mpim:history",
                "reactions:read",
                "reactions:write",
                "users:read"
            ]
        }
    },
    "settings": {
        "event_subscriptions": {
            "request_url": "https://XXX-XXX-XXX-XXX/slack/events",
            "bot_events": [
                "app_mention",
                "message.channels",
                "message.groups",
                "message.im",
                "message.mpim",
                "reaction_added"
            ]
        },
        "interactivity": {
            "is_enabled": true
        },
        "org_deploy_enabled": false,
        "socket_mode_enabled": true,
        "token_rotation_enabled": false
    }
}
```

## その他
sl_main.pyの各関数のbody_stは型ヒントが効くようになっている。
関数ごとにヒントが異なることが確かめられる。
型ヒントの詳細は：https://github.com/AIIT-OikawaPBL-2023/slack_bolt_sample/pull/37を参照すること。