### PR TITLE
Sb11：Cloudrun にデプロイ可能にするために Flask を導入する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM mcr.microsoft.com/devcontainers/python:0-3.11
 COPY requirements.txt .
 RUN pip install -r requirements.txt
+# MOB Dockerfile production用も作成する

--- a/mob_programming/main.py
+++ b/mob_programming/main.py
@@ -13,6 +13,23 @@ from rich import print
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 
+from flask import Flask, request
+from slack_bolt.adapter.flask import SlackRequestHandler
+
+flask_app = Flask(__name__)
+handler = SlackRequestHandler(app)
+
+@flask_app.route("/slack/events", methods=["POST"])
+def slack_events():
+    payload = request.get_json()
+    if 'challenge' in payload:
+        # これはチャレンジリクエストです。アプリを確認するためにチャレンジ値で応答してください。
+        # ref: https://qiita.com/masa_masa_ra/items/618779e698921cb53cec
+        return payload['challenge']
+    else:
+        # これは通常のイベントです。SlackRequestHandlerで処理してください。
+        return handler.handle(request)
+    
 # 環境変数を設定
 load_dotenv()
 # os.environ["OPENAI_API_KEY"] = os.environ.get("OPENAI_API_KEY")
@@ -196,7 +213,7 @@ def fetch_records_for_week(semester=None, week=None):
 
     return results
 
-
+# MOB flask_app.runで書き換え
 # アプリを起動します
 if __name__ == "__main__":
     mention_text = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ rich
 flask
 notion_client
 PyGithub
+gunicorn>=20


### PR DESCRIPTION
## チケット
https://www.notion.so/Cloudrun-Web-Flask-Socket-Event-Subscription-35d24fa80c484f17b9684f6a6e4f9685


## やったこと
> このプルリクで何をしたのか？
mob_programmingディレクトリ内のコードにFlaskを導入した

## できるようになること（ユーザ目線）
CloudRunにデプロイして動作するようになる

## 動作させるために必要な前準備
> どのような動作確認するためにどのような前準備をすればいいか

### Slack関連
> ソケットモードは「ON・OFF」どちらですか？　関係がない場合はこちらの項目を削除してください


## 実行手順
> 変更があったり記載したほうがいいと思った場合に記入


## その他
> レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

