### PR TITLE
[sb16・再] READMEにOSごとのコマンドを記載

### DIFF
--- a/cloudrun-sample/README.md
+++ b/cloudrun-sample/README.md
@@ -46,11 +46,24 @@ docker run -p 11111:11111 --env-file .env  my_app
 
 
 ## CloudRun
+
+### for Linux or Mac
+```bash
 export SLACK_APP_TOKEN=xxxxxxxxxxxx
 export SLACK_BOT_TOKEN=xxxxxxxxxxxx
 export SLACK_SIGNING_SECRET=xxxxxxxxxxxx
 gcloud builds submit --tag gcr.io/$PROJECT_ID/helloworld
-gcloud run deploy helloworld --image gcr.io/$PROJECT_ID/helloworld --platform managed --update-env-vars SLACK_SIGNING_SECRET=$SLACK_APP_TOKEN,SLACK_BOT_TOKEN=$SLACK_BOT_TOKEN,SLACK_SIGNING_SECRET=$SLACK_SIGNING_SECRET
+gcloud run deploy helloworld --image gcr.io/$PROJECT_ID/helloworld --platform managed --update-env-vars SLACK_BOT_TOKEN=$SLACK_BOT_TOKEN,SLACK_SIGNING_SECRET=$SLACK_SIGNING_SECRET
+```
+
+### for Windows
+```powershell
+set SLACK_APP_TOKEN=xxxxxxxxxxxx
+set SLACK_BOT_TOKEN=xxxxxxxxxxxx
+set SLACK_SIGNING_SECRET=xxxxxxxxxxxx
+gcloud builds submit --tag gcr.io/%PROJECT_ID%/helloworld
+gcloud run deploy helloworld --image gcr.io/%PROJECT_ID%/helloworld --platform managed --update-env-vars SLACK_BOT_TOKEN=%SLACK_BOT_TOKEN%,SLACK_SIGNING_SECRET=%SLACK_SIGNING_SECRET%
+```
 
 ## 設定
 https://{ngrokやcloudrunのエンドポイント}/slack/events


### PR DESCRIPTION
ブランチ名を変更して再度プルリク出させていただきます。
#46 の修正
https://github.com/AIIT-OikawaPBL-2023/slack_bolt_sample/pull/46#issuecomment-1638205646

## チケット
> スプリントバックログのURLなどを記入してください

https://www.notion.so/PB1-Cloudrun-2dc850d2f2c6492eb7bfcf60e32e4484?pvs=4


## やったこと
> このプルリクで何をしたのか？

モブプロにおいてREADMEを更新してcloudrunデプロイ時のWindowsでのコマンドを記載した


## できるようになること（ユーザ目線）
> 何ができるようになるのか？（あれば。無いなら「無し」でOK）

無し

## 動作させるために必要な前準備
> どのような動作確認するためにどのような前準備をすればいいか

無し

### Slack関連
> ソケットモードは「ON・OFF」どちらですか？　関係がない場合はこちらの項目を削除してください

無し

## 実行手順
> 変更があったり記載したほうがいいと思った場合に記入

無し

## その他
> レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

無し